### PR TITLE
🧑‍💻 fix(tests): remove deprecated usages

### DIFF
--- a/app/crud/crud_vocab.py
+++ b/app/crud/crud_vocab.py
@@ -28,7 +28,7 @@ def update(db: Session, id: int, vocab_in) -> Vocab:
     """
     Receive vocab id and get the data
     """
-    vocab = db.query(Vocab).get(id)
+    vocab = db.get(Vocab, id)
 
     for k, v in vocab_in:
         setattr(vocab, k, v)

--- a/app/db/base_class.py
+++ b/app/db/base_class.py
@@ -1,7 +1,8 @@
 from typing import Any, cast
 
 from sqlalchemy import Column, Integer
-from sqlalchemy.ext.declarative import as_declarative, declared_attr
+from sqlalchemy.ext.declarative import declared_attr
+from sqlalchemy.orm import as_declarative
 
 
 @as_declarative()

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,7 +1,7 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class UserBase(BaseModel):
@@ -11,7 +11,7 @@ class UserBase(BaseModel):
 
 
 class UserRead(UserBase):
-    created_at: Union[datetime, None]
+    created_at: Union[datetime, None] = None
 
 
 class UserCreate(UserBase):
@@ -23,12 +23,10 @@ class UserUpdate(UserBase):
 
 
 class UserInDBBase(UserBase):
-    id: int = Field(example=1)
-    created_at: datetime = Field(example=datetime.utcnow())
-    updated_at: Union[datetime, None]
-
-    class Config:
-        orm_mode = True
+    id: int = Field(examples=[1])
+    created_at: datetime = Field(examples=[datetime.now(UTC)])
+    updated_at: Union[datetime, None] = None
+    model_config = ConfigDict(from_attributes=True)
 
 
 class User(UserInDBBase):


### PR DESCRIPTION
Before this PR, running `make test` will see 7 warnings (mostly) raised by Pydantic and SQLAlchemy. After this PR these deprecated warnings are fixed.