### PR TITLE
🐛 fix(makefile): allow uv lock to update without frozen mode (#89)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ test: ## Run tests
 
 update-lockfile: ## Update the project's lockfile
 	@echo "$(WHALE) $@"
-	@uv lock --frozen
+	@uv lock
 
 export-requirements: ## Export the lockfile to requirements.txt
 	@echo "$(WHALE) $@"


### PR DESCRIPTION
Remove --frozen from update-lockfile target so uv can resolve and regenerate the lockfile during updates, preventing failures when dependency changes require a new lock state.

Signed-off-by: Mao-Kai Lan <45162039+mukappalambda@users.noreply.github.com>
