### PR TITLE
🧹 fix(makefile): improve clean target behavior (#91)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,9 @@ SHELL := /bin/bash
 help: ## Show help message
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
 
-clean: ## Remove __pycache__ and .pytest_cache
+clean: ## Remove all untracked files and directories (git clean -xdf)
 	@echo "$(WHALE) $@"
-	@find . -type d -name '__pycache__' | xargs -I{} rm -rf {}
-	@find ./app -name ".pytest_cache" | xargs rm -rf
+	@git clean -xdf
 
 install: ## Install project dependencies
 	@echo "$(WHALE) $@"


### PR DESCRIPTION
Replace manual cache directory removals with `git clean -xdf` to delete all untracked files and directories, ensuring a consistent and thorough cleanup across the repository.

Signed-off-by: Mao-Kai Lan <45162039+mukappalambda@users.noreply.github.com>
